### PR TITLE
Added support for Windows New Line Characters (\r\n)

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -17,8 +17,8 @@ var SINGLE_MODULE_TPL_END = '})();\n';
 
 // Regular Expressions that match <script type="text/ng-template" id="templateId">...</script>
 var SCRIPT_RES = [
-  new RegExp('<script[^>]*?\\bid="([^"]+)"[^>]*?\\btype="text/ng-template"[^>]*?>((.|\\n)*?)</script>', 'im'),
-  new RegExp('<script[^>]*?\\btype="text/ng-template"[^>]*?\\bid="([^"]+)"[^>]*?>((.|\\n)*?)</script>', 'im')
+  new RegExp('<script[^>]*?\\bid="([^"]+)"[^>]*?\\btype="text/ng-template"[^>]*?>((.|\\r|\\n)*?)</script>', 'im'),
+  new RegExp('<script[^>]*?\\btype="text/ng-template"[^>]*?\\bid="([^"]+)"[^>]*?>((.|\\r|\\n)*?)</script>', 'im')
 ];
 
 var escapeContent = function(content) {


### PR DESCRIPTION
Only Mac/Linux newline characters were accounted for (\n). This commit allows the regex to match Windows style new lines, too.
